### PR TITLE
:twisted_rightwards_arrows: add simple api to store and call LuaFunct…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,57 +1,73 @@
 mod libs;
 
-use libs::lua::module::{
-	get_or_create_module,
-	get_or_create_sub_module,
-};
-use mlua::{
-	prelude::*,
-	Lua,
-	Table,
-	UserData,
-	Value,
-};
-use serde::Deserialize;
-use std::{
-	env::var,
-	fs::read_to_string,
-};
+use libs::lua::module::{get_or_create_module, get_or_create_sub_module};
+use mlua::{prelude::*, Lua, Table, UserData, Value};
+use std::{env::var, fs::read_to_string};
 
 struct StrataState;
 
 impl StrataState {
-	pub fn spawn(_: &Lua, cmd: String) -> LuaResult<()> {
-		println!("Received command: {}", cmd);
-		Ok(())
-	}
-	pub fn set_bindings<'a>(_: &'a Lua, bindings: LuaTable<'a>) -> LuaResult<LuaTable<'a>> {
-		Ok(bindings)
-	}
+    pub fn spawn(_: &Lua, cmd: String) -> LuaResult<()> {
+        println!("Spawning {}", cmd.to_string());
+        Ok(())
+    }
+}
+
+struct StrataConfig;
+
+impl StrataConfig {
+    pub fn spawn(lua: &Lua, cmd: String) -> LuaResult<LuaFunction> {
+        let func = lua
+            .load(format!(
+                r#"
+            local strata = require("strata")
+            strata.api.spawn("{}")"#,
+                cmd
+            ))
+            .into_function()?;
+        // table.set("cmd", cmd)?;
+        Ok(func)
+    }
+    pub fn set_bindings<'a>(_: &'a Lua, bindings: Table<'a>) -> LuaResult<()> {
+        println!("{:#?}", bindings);
+        for key in bindings.sequence_values::<Table>() {
+            // Debug for each settings This should Deserialize to Bindings struct
+            let table: Table = key?.clone();
+            let keys: Vec<String> = table.get("keys")?;
+            let cmd: LuaFunction = table.get("cmd")?;
+            println!("{:#?}", keys);
+            println!("{:#?}", cmd);
+            // Try to call lua functions
+            println!("{:?}", cmd.call(0)?)
+        }
+        Ok(())
+    }
 }
 
 fn main() -> anyhow::Result<()> {
-	let lua = Lua::new();
-	let config_path =
-		format!("{}/.config/strata/strata.lua", var("HOME").expect("This should always be set!!!"));
-	let config_str = read_to_string(config_path).unwrap();
+    let lua = Lua::new();
+    let config_path = format!(
+        "{}/.config/strata/strata.lua",
+        var("HOME").expect("This should always be set!!!")
+    );
+    let config_str = read_to_string(config_path).unwrap();
 
-	// Create a new module
-	let strata_mod = get_or_create_module(&lua, "strata")?;
-	let cmd_submod = get_or_create_sub_module(&lua, "cmd")?;
+    // Create a new module
+    let strata_mod = get_or_create_module(&lua, "strata")?;
+    let cmd_submod = get_or_create_sub_module(&lua, "cmd")?;
+    let api_submod = get_or_create_sub_module(&lua, "api")?;
 
-	let set_bindings = lua.create_function_mut(move |_, keybinds: Table| {
-		for binding_table in keybinds.sequence_values::<Table>() {
-			let keys: Vec<String> = binding_table.clone().unwrap().get("keys")?;
-			let cmd: String = binding_table.clone().unwrap().get("cmd")?;
-			println!("Keys: {:?}, Cmd: {}", keys, cmd);
-		}
-		Ok(())
-	})?;
+    // Create "spawn config" for strata.cmd to construct LuaFunction and use it later.
+    cmd_submod.set("spawn", lua.create_function(StrataConfig::spawn)?)?;
+    // Create "spawn api" for strata.api that can triggers LuaFunction as needed.
+    api_submod.set("spawn", lua.create_function(StrataState::spawn)?)?;
 
-	cmd_submod.set("spawn", lua.create_function(StrataState::spawn)?)?;
-	strata_mod.set("set_bindings", set_bindings)?;
+    strata_mod.set(
+        "set_bindings",
+        lua.create_function(StrataConfig::set_bindings)?,
+    )?;
 
-	lua.load(&config_str).exec()?;
+    lua.load(&config_str).exec()?;
 
-	Ok(())
+    Ok(())
 }


### PR DESCRIPTION
Hey I got an Idea after playing for some time. How about we use `strata.cmd` to build `LuaFunction` with `lua.load().into_function()` that holding something like this.
![image](https://github.com/anantnrg/lua_rust/assets/8637706/d6f0ca12-2e4b-46ad-8953-e90a36257216)

 this way We can store functions from `strata.cmd.spawn()` into struct,  rather got it excuted right away and we can't event seen it in the `LuaTable`.  and we have to implements the real `strata.api` for all workaround we can think of it which can be apply any change to `Strata` at any time.
 
![image](https://github.com/anantnrg/lua_rust/assets/8637706/8d2d7251-d0a9-4ef8-a0c2-a8dd28c4fd24)
